### PR TITLE
correctly handle string input

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = function (re, opts) {
 
   let pattern = null;
   if (isRegExp(re)) pattern = re.source;
-  else if (typeof re !== 'string') pattern = String(re);
-  else return false;
+  else if (typeof re === 'string') pattern = re;
+  else pattern = String(re);
 
   let ast = null;
   try { ast = regexpTree.parse(`/${pattern}/`) }

--- a/test/regex.js
+++ b/test/regex.js
@@ -8,6 +8,7 @@ var good = [
     /^\d+(1337|404)\d+$/i,
     /^\d+(1337|404)*\d+$/i,
     RegExp(Array(26).join('a?') + Array(26).join('a')),
+    'aaa'
 ];
 
 test('safe regex', function (t) {
@@ -25,7 +26,8 @@ var bad = [
     /foo|(x+x+)+y/,
     /(a+){10}y/,
     /(a+){2}y/,
-    /(.*){1,32000}[bc]/
+    /(.*){1,32000}[bc]/,
+    '(a+)+'
 ];
 
 test('unsafe regex', function (t) {


### PR DESCRIPTION
Problem:
The switch from ret to regexp-tree introduced
a 'pattern' variable to differentiate from the 're' input.
This variable was not initialized correctly so strings were
rejected.