### PR TITLE
bug: fix '/regex-in-string/' handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,15 @@ module.exports = function (re, opts) {
   else pattern = String(re);
 
   let ast = null;
-  try { ast = regexpTree.parse(`/${pattern}/`) }
-  catch (err) { return false }
+  try {
+    ast = regexpTree.parse(pattern);
+  } catch (err) {
+    try {
+      ast = regexpTree.parse(`/${pattern}/`); }
+    catch (err) {
+      return false;
+    }
+  }
 
   let currentStarHeight = 0;
   let maxObservedStarHeight = 0;
@@ -35,7 +42,7 @@ module.exports = function (re, opts) {
     }
   });
 
-	return (maxObservedStarHeight <= 1) && (repetitionCount <= replimit);
+  return (maxObservedStarHeight <= 1) && (repetitionCount <= replimit);
 };
 
 function isRegExp (x) {

--- a/test/regex.js
+++ b/test/regex.js
@@ -10,7 +10,8 @@ var good = [
     /(a+)|(b+)/,
     RegExp(Array(26).join('a?') + Array(26).join('a')),
     // String input.
-    'aaa'
+    'aaa',
+    '/^\d+(1337|404)*\d+$/'
 ];
 
 test('safe regex', function (t) {


### PR DESCRIPTION
This is a more creative input format I found in eslint-plugin-security.
It worked in ret but not in regexp-tree without some tweaks.

Fixes: #18