### PR TITLE
fix: handle strings with unescaped forward slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,20 +4,24 @@ module.exports = function (re, opts) {
   if (!opts) opts = {};
   const replimit = opts.limit === undefined ? 25 : opts.limit;
 
-  let pattern = null;
-  if (isRegExp(re)) pattern = re.source;
-  else if (typeof re === 'string') pattern = re;
-  else pattern = String(re);
-
+  // Build an AST
+  let myRegExp = null;
   let ast = null;
   try {
-    ast = regexpTree.parse(pattern);
-  } catch (err) {
-    try {
-      ast = regexpTree.parse(`/${pattern}/`); }
-    catch (err) {
-      return false;
+    // Construct a RegExp object
+    if (re instanceof RegExp) {
+      myRegExp = re;
+    } else if (typeof re === 'string') {
+      myRegExp = new RegExp(re);
+    } else {
+      myRegExp = new RegExp(String(re));
     }
+
+    // Build an AST
+    ast = regexpTree.parse(myRegExp);
+  } catch (err) {
+    // Invalid or unparseable input
+    return false;
   }
 
   let currentStarHeight = 0;
@@ -44,7 +48,3 @@ module.exports = function (re, opts) {
 
   return (maxObservedStarHeight <= 1) && (repetitionCount <= replimit);
 };
-
-function isRegExp (x) {
-    return {}.toString.call(x) === '[object RegExp]';
-}

--- a/test/regex.js
+++ b/test/regex.js
@@ -11,7 +11,8 @@ var good = [
     RegExp(Array(26).join('a?') + Array(26).join('a')),
     // String input.
     'aaa',
-    '/^\d+(1337|404)*\d+$/'
+    '/^\d+(1337|404)*\d+$/',
+    '^@types/query-string'
 ];
 
 test('safe regex', function (t) {


### PR DESCRIPTION
Problem:
I was sending strings to regexp-tree instead of regexes.
regexp-tree strings need to have '/.../' so I was wrapping regexes-as-strings with forward slashes.
If the string already contained an unescaped forward slash, then it would no longer be a valid regex, and parsing it would fail.
Example: ^abc/ --> /^abc//
If safe-regex can't parse a regex, it returns false.

Solution:
Send RegExp objects to regexp-tree.

Fixes: #20