### PR TITLE
Update regexp-tree to resolve vulnerability of mem

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "detect possibly catastrophic, exponential-time regular expressions",
   "main": "index.js",
   "dependencies": {
-    "regexp-tree": "~0.0.85"
+    "regexp-tree": "~0.1.1"
   },
   "devDependencies": {
     "tape": "^3.5.0"


### PR DESCRIPTION
Info: https://app.snyk.io/test/npm/safe-regex

This is fixed in regex-tree@0.1.1
- https://app.snyk.io/test/npm/regexp-tree/0.1.1
- https://github.com/DmitrySoshnikov/regexp-tree/pull/171