### PR TITLE
Update test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.vscode
+coverage
 node_modules/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ regular expressions by limiting the
 WARNING: This module has both false positives and false negatives.
 Use [vuln-regex-detector](https://github.com/davisjam/vuln-regex-detector) for improved accuracy.
 
-[![browser support](https://ci.testling.com/substack/safe-regex.png)](https://ci.testling.com/substack/safe-regex)
-
 [![build status](https://secure.travis-ci.org/substack/safe-regex.png)](http://travis-ci.org/substack/safe-regex)
 
 # Example

--- a/package.json
+++ b/package.json
@@ -7,20 +7,33 @@
     "regexp-tree": "~0.1.1"
   },
   "devDependencies": {
-    "tape": "^3.5.0"
+    "jest": "^24.9.0"
   },
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "jest"
   },
-  "testling": {
-    "files": "test/*.js",
-    "browsers": [
-      "ie/8", "ie/9", "ie/10", 
-      "firefox/latest",
-      "chrome/latest",
-      "opera/latest",
-      "safari/latest"
-    ]
+  "jest": {
+    "moduleFileExtensions": [
+      "js"
+    ],
+    "testRegex": "test.*\\.spec\\.js$",
+    "collectCoverage": true,
+    "coverageReporters": [
+      "text-summary",
+      "html",
+      "lcov"
+    ],
+    "collectCoverageFrom": [
+      "*.js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 96,
+        "branches": 75,
+        "functions": 100,
+        "lines": 95
+      }
+    }
   },
   "repository": {
     "type": "git",

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -1,5 +1,4 @@
 var safe = require('../');
-var test = require('tape');
 
 var good = [
     /\bOakland\b/,
@@ -15,10 +14,9 @@ var good = [
     '^@types/query-string'
 ];
 
-test('safe regex', function (t) {
-    t.plan(good.length);
+test('safe regex', function () {
     good.forEach(function (re) {
-        t.equal(safe(re), true);
+        expect(safe(re)).toBe(true);
     });
 });
 
@@ -40,10 +38,9 @@ var bad = [
     '(a+)+'
 ];
 
-test('unsafe regex', function (t) {
-    t.plan(bad.length);
+test('unsafe regex', function () {
     bad.forEach(function (re) {
-        t.equal(safe(re), false);
+        expect(safe(re)).toBe(false);
     });
 });
 
@@ -54,9 +51,8 @@ var invalid = [
     '[abc'
 ];
 
-test('invalid regex', function (t) {
-    t.plan(invalid.length);
+test('invalid regex', function () {
     invalid.forEach(function (re) {
-        t.equal(safe(re), false);
+        expect(safe(re)).toBe(false);
     });
 });


### PR DESCRIPTION
## what's in here

- replaces _tape_ with _jest_ (see #7 for rationale)
- updates the package.json so its `test` target runs jest (with coverage on) and a jest configuration that adds:
  - minimum coverage (= I've taken the current coverage for this so any ci won't bork on it)
  - three coverage reports
    - _text-summary_ - that gives direct feedback on the console
    - _html_ - which emits `coverage/index.html` which is helpful to identify what part of the code isn't covered well yet.
    - _lcov_ - which will be useful for services like coveralls or codeclimate
- removes the testling configuration + readme badge (as it's not used anymore and won't run out of the box with jest (or mocha, jasmine for that matter) anyway see #7 for rationale)
- adds the `coverage` folder to .gitignore as you probably don't want that one checked in.

## why?

- fixes #7


## sample output

### console
<img width="576" alt="image" src="https://user-images.githubusercontent.com/4822597/66270913-ddf38180-e858-11e9-994b-2376526ccb92.png">

### html
<img width="681" alt="image" src="https://user-images.githubusercontent.com/4822597/66270934-07141200-e859-11e9-87ea-0bd4b14440c1.png">

