### PR TITLE
Improve test suite coverage to 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 96,
-        "branches": 75,
+        "statements": 100,
+        "branches": 100,
         "functions": 100,
-        "lines": 95
+        "lines": 100
       }
     }
   },

--- a/test/regex.spec.js
+++ b/test/regex.spec.js
@@ -1,58 +1,84 @@
-var safe = require('../');
+const safeRegex = require('../');
 
-var good = [
-    /\bOakland\b/,
-    /\b(Oakland|San Francisco)\b/i,
-    /^\d+1337\d+$/i,
-    /^\d+(1337|404)\d+$/i,
-    /^\d+(1337|404)*\d+$/i,
-    /(a+)|(b+)/,
-    RegExp(Array(26).join('a?') + Array(26).join('a')),
-    // String input.
-    'aaa',
-    '/^\d+(1337|404)*\d+$/',
-    '^@types/query-string'
-];
+const REPETITION_LIMIT = 25;
+const REPETITION_TOO_MUCH = REPETITION_LIMIT + 1;
 
-test('safe regex', function () {
-    good.forEach(function (re) {
-        expect(safe(re)).toBe(true);
+test('safe regex', () => {
+    const good = [
+        // regular RE's
+        /\bOakland\b/,
+        /\b(Oakland|San Francisco)\b/i,
+        /^\d+1337\d+$/i,
+        /^\d+(1337|404)\d+$/i,
+        /^\d+(1337|404)*\d+$/i,
+        /(a+)|(b+)/,
+        RegExp('a?'.repeat(REPETITION_LIMIT) + 'a'.repeat(REPETITION_LIMIT)),
+        
+        // RE's in a string
+        '/^\d+(1337|404)*\d+$/',
+        '^@types/query-string',
+        
+        // normal string
+        'aaa',
+        
+        // non-RE, non-string
+        1
+    ];
+
+    good.forEach(re => {
+        expect(safeRegex(re)).toBe(true);
     });
 });
 
+test('safe regex with custom repetition limit', () => {
+    const LOW_REPETITION_LIMIT = 3;
+    const re = RegExp(Array(LOW_REPETITION_LIMIT).join('a?'));
 
-var bad = [
-    /^(a?){25}(a){25}$/,
-    RegExp(Array(27).join('a?') + Array(27).join('a')),
-    /(x+x+)+y/,
-    /foo|(x+x+)+y/,
-    /(a+){10}y/,
-    /(a+){2}y/,
-    /(.*){1,32000}[bc]/,
-    // Star height with branching and nesting.
-    /(a*|b)+$/,
-    /(a|b*)+$/,
-    /(((b*)))+$/,
-    /(((b*))+)$/,
-    // String input.
-    '(a+)+'
-];
+    expect(safeRegex(re, {limit: LOW_REPETITION_LIMIT})).toBe(true);
+});
 
-test('unsafe regex', function () {
-    bad.forEach(function (re) {
-        expect(safe(re)).toBe(false);
+test('unsafe regex', () => {
+    const bad = [
+        // regular RE's
+        /^(a?){25}(a){25}$/,
+        RegExp('a?'.repeat(REPETITION_TOO_MUCH) + 'a'.repeat(REPETITION_TOO_MUCH)),
+        /(x+x+)+y/,
+        /foo|(x+x+)+y/,
+        /(a+){10}y/,
+        /(a+){2}y/,
+        /(.*){1,32000}[bc]/,
+        
+        // Star height with branching and nesting.
+        /(a*|b)+$/,
+        /(a|b*)+$/,
+        /(((b*)))+$/,
+        /(((b*))+)$/,
+        
+        // RE's in a string
+        '(a+)+'
+    ];
+
+    bad.forEach(re => {
+        expect(safeRegex(re)).toBe(false);
     });
 });
 
-var invalid = [
-    '*Oakland*',
-    'hey(yoo))',
-    'abcde(?>hellow)',
-    '[abc'
-];
+test('unsafe regex with custom repetition limit', () => {
+    const LOW_REPETITION_LIMIT = 3;
+    const re = RegExp('a?'.repeat(LOW_REPETITION_LIMIT + 1));
 
-test('invalid regex', function () {
-    invalid.forEach(function (re) {
-        expect(safe(re)).toBe(false);
+    expect(safeRegex(re, {limit: LOW_REPETITION_LIMIT})).toBe(false);
+});
+
+test('invalid regex', () => {
+    const invalid = [
+        '*Oakland*',
+        'hey(yoo))',
+        'abcde(?>hellow)',
+        '[abc'
+    ];
+
+    invalid.forEach(re => {
+        expect(safeRegex(re)).toBe(false);
     });
 });


### PR DESCRIPTION
## what's in here?

- expands the test scenarios to provide 100% coverage
  - adds a scenario to cover the treatment of non-string, non-RE inputs
  - adds scenarios to ensure custom reputation limits are respected
- also used slightly more modern javascript (const, string repeat instead of empty array join - because of the wish to support node > 6 in #9) and put constants only used in one function into these functions.
- Up'ed the coverage limits in package.json too 100% so an `npm test` will fail if code is added that isn't covered by a test.

## why?

- fixes #6 
- addresses #8 - although it'll need ci integration to ensure the coverage stays at 100 and fully consider #8 fixed.