### PR TITLE
ci(travis): set latest node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
+sudo: required
+
 language: node_js
+
 node_js:
-  - "0.8"
-  - "0.10"
+  - "10"
+  - "12"
+
+install:
+  - npm install
+
+script:
+  - npm test
+
+cache:
+  directories:
+    - node_modules

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ regular expressions by limiting the
 WARNING: This module has both false positives and false negatives.
 Use [vuln-regex-detector](https://github.com/davisjam/vuln-regex-detector) for improved accuracy.
 
-[![build status](https://secure.travis-ci.org/substack/safe-regex.png)](http://travis-ci.org/substack/safe-regex)
+[![Build Status](https://travis-ci.com/davisjam/safe-regex.svg?branch=master)](https://travis-ci.com/davisjam/safe-regex)
 
 # Example
 


### PR DESCRIPTION
## what's in here?

- A Travis config with 
  - the latest 2 versions of node (as discussed in #9)
  - test (coverage) script
  - cache config for node_modules
- Updated readme with travis swag icon & link pointing to the davisjam repo


## why, though?

fixes #9 and (once travis is enabled) #8 

## how's this tested?

By enabling travis on the fork. Results [for the first build](https://travis-ci.com/sverweij/safe-regex/builds/131702400), [for the branch of the PR, on github](https://github.com/sverweij/safe-regex/runs/258375720) and [for the second build, on travis-ci.com](https://travis-ci.com/sverweij/safe-regex/builds/131702719).

## next steps

- enable travis for davisjam/safe-regex (only @davisjam can do that afaik)
- specify the minimum requirements to the node environment in package.json's `engines` field so packages with old, unsupported versions of nodejs don't accicentally install safe-regex.
