### PR TITLE
feat: add TS type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.2",
   "description": "detect possibly catastrophic, exponential-time regular expressions",
   "main": "dist/index.js",
+  "types": "typings/index.d.ts",
   "dependencies": {
     "babel-jest": "^26.3.0",
     "regexp-tree": "~0.1.1"

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Checks if a regex is safe to use in order to prevent catastrophic backtracking.
+ * @param regex can be a RegExp object or just a string.
+ * @param options Options for the check.
+ * `limit` - maximum number of allowed repetitions in the entire regex. Default: `25`.
+ */
+export default function safe(regex: string | RegExp, options?: Options): boolean;
+
+export type Options = Partial<{
+    /** Maximum number of allowed repetitions in the entire regex. Default `25` */
+    limit: number
+}> 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,7 +4,7 @@
  * @param options Options for the check.
  * `limit` - maximum number of allowed repetitions in the entire regex. Default: `25`.
  */
-export default function safe(regex: string | RegExp, options?: Options): boolean;
+export default function safeRegex(regex: string | RegExp, options?: Options): boolean;
 
 export type Options = Partial<{
     /** Maximum number of allowed repetitions in the entire regex. Default `25` */


### PR DESCRIPTION
This PR adds built-in TS type definitions taken from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/safe-regex (aka npmjs.com/package/@types/safe-regex)

Note for the future and for maintainability: these types only need to be changed if:
 - A new export is added to the package (either a function, object, etc)
 - A new parameter is added to the function
 - A new option is added to the options interface

In order to update the options, simply add a new line after the existing one and type the name of the option followed by its type. You can see TS's most basic types here: https://www.w3schools.com/typescript/typescript_simple_types.php

If adding a new export that isn't the default export, simply declare it with the `export` keyword before it. Be sure to give it the same name it has in the code!